### PR TITLE
Update 01.Linear-DP-01.md

### DIFF
--- a/Contents/10.Dynamic-Programming/03.Linear-DP/01.Linear-DP-01.md
+++ b/Contents/10.Dynamic-Programming/03.Linear-DP/01.Linear-DP-01.md
@@ -83,7 +83,7 @@
 
 - 如果 $nums[j] < nums[i]$，则 $nums[i]$ 可以接在 $nums[j]$ 后面，此时以 $nums[i]$ 结尾的最长递增子序列长度会在「以 $nums[j]$ 结尾的最长递增子序列长度」的基础上加 $1$，即：$dp[i] = dp[j] + 1$。
 
-- 如果 $nums[j] \le nums[i]$，则 $nums[i]$ 不可以接在 $nums[j]$ 后面，可以直接跳过。
+- 如果 $nums[j] \ge nums[i]$，则 $nums[i]$ 不可以接在 $nums[j]$ 后面，可以直接跳过。
 
 综上，我们的状态转移方程为：$dp[i] = max(dp[i], dp[j] + 1), 0 \le j < i, nums[j] < nums[i]$。
 


### PR DESCRIPTION
correct typo of linear dp
应该是nums[j]>=nums[i]